### PR TITLE
Update to support Dart 1.20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ To activate the program for global use, run `pub global activate dart_coveralls`
 This command calculates the coverage of a given package. Use the tool like this:
 
 ```
-dart_coveralls calc [--workers, --output, --package-root] test.dart
+dart_coveralls calc [--workers, --output, --packages] test.dart
 ```
 
 * `--workers`: The number of workers used to parse LCOV information
 * `--output`: The output file path, if not given stdout
-* `--package-root`: Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages`: Path to .packages file -- controls "package:..." import paths.
+  (defaults to ".packages")
 * `test.dart`: The path of the test file on which coverage will be collected
 
 #### The `report` command
@@ -40,8 +40,8 @@ dart_coveralls report <options> <test file>
 * `--token` –Token for coveralls
 * `--workers` – Number of workers for parsing
   (defaults to "1")
-* `--package-root` Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages` Path to .packages file -- controls "package:..." import paths.
+  (defaults to ".packages")
 * `--debug` Prints debug information
 * `--retry` Number of retries
   (defaults to "10")
@@ -66,8 +66,8 @@ dart_coveralls upload <options> <directory containing coverage reports from the 
 * `--token` –Token for coveralls
 * `--workers` – Number of workers for parsing
   (defaults to "1")
-* `--package-root` Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages` Path to .packages file -- controls "package:..." import paths.
+  (defaults to ".packages")
 * `--debug` Prints debug information
 * `--retry` Number of retries
   (defaults to "10")

--- a/bin/src/calc.dart
+++ b/bin/src/calc.dart
@@ -17,15 +17,8 @@ class CalcPart extends CommandLinePart {
       return;
     }
 
-    String packageRoot = res["package-root"];
-    if (p.isRelative(packageRoot)) {
-      packageRoot = p.absolute(packageRoot);
-    }
-
-    if (!FileSystemEntity.isDirectorySync(packageRoot)) {
-      print("Package root directory does not exist");
-      return;
-    }
+    String packagesPath = handlePackagesArg(res);
+    if (packagesPath == null) return;
 
     if (res.rest.length != 1) {
       print("Please specify a test file to run");
@@ -43,7 +36,7 @@ class CalcPart extends CommandLinePart {
     }
 
     var workers = int.parse(res["workers"]);
-    var collector = new LcovCollector(packageRoot);
+    var collector = new LcovCollector(packagesPath);
 
     var r = await collector.getLcovInformation(file, workers: workers);
 
@@ -56,10 +49,10 @@ class CalcPart extends CommandLinePart {
   }
 }
 
-ArgParser _initializeParser() => new ArgParser(allowTrailingOptions: true)
-  ..addFlag("help", help: "Prints this help", negatable: false)
-  ..addOption("workers", help: "Number of workers for parsing", defaultsTo: "1")
-  ..addOption("output", help: "Output file path")
-  ..addOption("package-root",
-      help: 'Where to find packages, that is, "package:..." imports.',
-      defaultsTo: "packages");
+ArgParser _initializeParser() {
+  ArgParser parser = new ArgParser(allowTrailingOptions: true)
+    ..addOption("workers",
+        help: "Number of workers for parsing", defaultsTo: "1")
+    ..addOption("output", help: "Output file path");
+  return CommandLinePart.addCommonOptions(parser);
+}

--- a/bin/src/command_line.dart
+++ b/bin/src/command_line.dart
@@ -1,16 +1,46 @@
 library cmdpart;
 
 import 'dart:async';
+import 'dart:io' show FileSystemEntity;
 import "dart:math" show max;
 
 import "package:args/args.dart";
+import 'package:path/path.dart' as p;
+import 'package:logging/logging.dart';
 
 export "package:args/args.dart";
+
+final Logger _log = new Logger("dart_coveralls");
 
 abstract class CommandLinePart {
   final ArgParser parser;
 
   CommandLinePart(this.parser);
+
+  String handlePackagesArg(ArgResults res) {
+    String packagesPath = res["packages"];
+    if (p.isRelative(packagesPath)) {
+      packagesPath = p.absolute(packagesPath);
+    }
+
+    if (!FileSystemEntity.isFileSync(packagesPath)) {
+      print("Packages file does not exist");
+      return null;
+    }
+
+    _log.info(() => "Packages file is ${packagesPath}");
+
+    return packagesPath;
+  }
+
+  static ArgParser addCommonOptions(ArgParser parser) {
+    return parser
+      ..addFlag("help", help: "Displays this help", negatable: false)
+      ..addOption("packages",
+          help:
+              'Path to .packages file -- controls "package:..." import paths.',
+          defaultsTo: ".packages");
+  }
 
   Future parseAndExecute(List<String> args) => execute(parser.parse(args));
 

--- a/bin/src/report.dart
+++ b/bin/src/report.dart
@@ -42,9 +42,9 @@ class ReportPart extends CommandLinePart {
 
     if (res.rest.length != 1) return print("Please specify a test file to run");
 
-    var pRoot = new Directory(res["package-root"]);
-    if (!pRoot.existsSync()) return print("Root directory does not exist");
-    log.info(() => "Package root is ${pRoot.absolute.path}");
+    var packagesPath = handlePackagesArg(res);
+    if (packagesPath == null) return null;
+    log.info(() => "Packages file is ${packagesPath}");
 
     var file = new File(res.rest.single);
     if (!file.existsSync()) return print("Dart file does not exist");
@@ -76,7 +76,7 @@ class ReportPart extends CommandLinePart {
 
     CoverallsResult result = await Chain.capture(() async {
       var commandLineClient =
-          new CommandLineClient(packageRoot: pRoot.absolute.path, token: token);
+          new CommandLineClient(packagesPath: packagesPath, token: token);
 
       return await commandLineClient.reportToCoveralls(file.absolute.path,
           workers: workers,
@@ -96,39 +96,42 @@ class ReportPart extends CommandLinePart {
 Iterable<String> get _logLevelOptions =>
     Level.LEVELS.map((l) => l.name.toLowerCase()).toList();
 
-ArgParser _initializeParser() => new ArgParser(allowTrailingOptions: true)
-  ..addFlag("help", help: "Displays this help", negatable: false)
-  ..addOption("token",
-      help: "Token for coveralls. If not provided environment values REPO_TOKEN"
-      " and COVERALLS_TOKEN are used if they exist.")
-  ..addOption("workers", help: "Number of workers for parsing", defaultsTo: "1")
-  ..addOption("package-root",
-      help: 'Where to find packages, that is, "package:..." imports.',
-      defaultsTo: "packages")
-  ..addFlag("debug",
-      help: "Prints all log information. Equivalent to `--log-level all`",
-      negatable: false)
-  ..addOption('log-level',
-      help: 'The level at which logs are printed.',
-      allowed: _logLevelOptions,
-      defaultsTo: 'off')
-  ..addOption("retry", help: "Number of retries", defaultsTo: "10")
-  ..addFlag("dry-run",
-      help: "If this flag is enabled, data won't be sent to coveralls",
-      negatable: false)
-  ..addFlag("throw-on-connectivity-error",
-      help: "Should this throw an " "exception, if the upload to coveralls fails?",
-      negatable: false,
-      abbr: "C")
-  ..addFlag("throw-on-error", help: "Should this throw if "
-      "an error in the dart_coveralls implementation happens?",
-      negatable: false,
-      abbr: "E")
-  ..addFlag("exclude-test-files",
-      abbr: "T",
-      help: "Should test files be included in the coveralls report?",
-      negatable: false)
-  ..addFlag("print-json",
-      abbr: 'p',
-      help: "Pretty-print the json that will be sent to coveralls.",
-      negatable: false);
+ArgParser _initializeParser() {
+  ArgParser parser = new ArgParser(allowTrailingOptions: true)
+    ..addOption("token",
+        help:
+            "Token for coveralls. If not provided environment values REPO_TOKEN"
+            " and COVERALLS_TOKEN are used if they exist.")
+    ..addOption("workers",
+        help: "Number of workers for parsing", defaultsTo: "1")
+    ..addFlag("debug",
+        help: "Prints all log information. Equivalent to `--log-level all`",
+        negatable: false)
+    ..addOption('log-level',
+        help: 'The level at which logs are printed.',
+        allowed: _logLevelOptions,
+        defaultsTo: 'off')
+    ..addOption("retry", help: "Number of retries", defaultsTo: "10")
+    ..addFlag("dry-run",
+        help: "If this flag is enabled, data won't be sent to coveralls",
+        negatable: false)
+    ..addFlag("throw-on-connectivity-error",
+        help: "Should this throw an "
+            "exception, if the upload to coveralls fails?",
+        negatable: false,
+        abbr: "C")
+    ..addFlag("throw-on-error",
+        help: "Should this throw if "
+            "an error in the dart_coveralls implementation happens?",
+        negatable: false,
+        abbr: "E")
+    ..addFlag("exclude-test-files",
+        abbr: "T",
+        help: "Should test files be included in the coveralls report?",
+        negatable: false)
+    ..addFlag("print-json",
+        abbr: 'p',
+        help: "Pretty-print the json that will be sent to coveralls.",
+        negatable: false);
+  return CommandLinePart.addCommonOptions(parser);
+}

--- a/lib/src/cli_client.dart
+++ b/lib/src/cli_client.dart
@@ -16,29 +16,27 @@ import 'services/travis.dart' as travis;
 
 class CommandLineClient {
   final String projectDirectory;
-  final String packageRoot;
+  final String packagesPath;
   final String token;
 
-  CommandLineClient._(this.projectDirectory, this.packageRoot, this.token);
+  CommandLineClient._(this.projectDirectory, this.packagesPath, this.token);
 
   factory CommandLineClient(
       {String projectDirectory,
-      String packageRoot,
+      String packagesPath,
       String token,
       Map<String, String> environment}) {
     if (projectDirectory == null) {
       projectDirectory = p.current;
     }
 
-    packageRoot = _calcPackageRoot(projectDirectory, packageRoot);
-
-    return new CommandLineClient._(projectDirectory, packageRoot, token);
+    return new CommandLineClient._(projectDirectory, packagesPath, token);
   }
 
   Future<CoverageResult<String>> getLcovResult(String testFile,
       {int workers, ProcessSystem processSystem: const ProcessSystem()}) {
     var collector =
-        new LcovCollector(packageRoot, processSystem: processSystem);
+        new LcovCollector(packagesPath, processSystem: processSystem);
     return collector.getLcovInformation(testFile, workers: workers);
   }
 
@@ -92,7 +90,7 @@ class CommandLineClient {
       bool excludeTestFiles: false,
       bool printJson}) async {
     var collector =
-        new LcovCollector(packageRoot, processSystem: processSystem);
+        new LcovCollector(packagesPath, processSystem: processSystem);
 
     var result = await collector.convertVmReportsToLcov(containsVmReports,
         workers: workers);
@@ -145,20 +143,6 @@ class CommandLineClient {
       return null;
     }
   }
-}
-
-String _calcPackageRoot(String packageDir, String packageRoot) {
-  assert(p.isAbsolute(packageDir));
-
-  if (packageRoot == null) {
-    packageRoot = 'packages';
-  }
-
-  if (p.isRelative(packageRoot)) {
-    packageRoot = p.join(packageDir, packageRoot);
-  }
-
-  return p.normalize(packageRoot);
 }
 
 Future<CoverallsResult> _sendLoop(CoverallsEndpoint endpoint, String covString,

--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -1,6 +1,7 @@
 library dart_coveralls.lcov;
 
 import "dart:async" show Future;
+import "dart:convert";
 import "dart:io";
 
 import "package:coverage/coverage.dart";
@@ -104,26 +105,23 @@ class LcovCollector {
   /// Generates and returns a coverage json file
   Future<CoverageResult<List<File>>> _getCoverageJson(
       String testFile, Directory coverageDir) async {
+    int observatoryPort = 8181; // FIXME: Should read out port instead?
     var args = [
-      "--coverage_dir=${coverageDir.path}",
       "--packages=${packagesPath}",
+      "--pause-isolates-on-exit",
+      "--enable-vm-service=${observatoryPort}",
       testFile
     ];
-    var result = await processSystem.runProcess(Platform.executable, args);
-    if (result.exitCode < 0) {
-      stderr.writeln('stdout:');
-      stderr.writeln(result.stdout);
-      stderr.writeln('stderr:');
-      stderr.writeln(result.stderr);
-      throw new ProcessException(
-          Platform.executable,
-          args,
-          'There was a critical error. Exit code: ${result.exitCode}',
-          result.exitCode);
-    }
+    Future<ProcessResult> testFuture =
+        processSystem.runProcess(Platform.executable, args);
+    final Map data = await collect('localhost', observatoryPort, true, false);
+
+    new File(p.join(coverageDir.path, 'coverage.json'))
+        .writeAsString(JSON.encode(data));
+
     var reportFiles =
         await coverageDir.list(recursive: false, followLinks: false).toList();
-    return new CoverageResult<List<File>>(reportFiles, result);
+    return new CoverageResult<List<File>>(reportFiles, await testFuture);
   }
 }
 

--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -50,10 +50,10 @@ class LcovPart {
 
 class LcovCollector {
   final String sdkRoot;
-  final String packageRoot;
+  final String packagesPath;
   final ProcessSystem processSystem;
 
-  LcovCollector(this.packageRoot,
+  LcovCollector(this.packagesPath,
       {this.processSystem: const ProcessSystem(), this.sdkRoot}) {}
 
   Future<CoverageResult<String>> convertVmReportsToLcov(
@@ -65,7 +65,7 @@ class LcovCollector {
         .toList();
 
     var hitmap = await parseCoverage(reportFiles, workers);
-    var resolver = new Resolver(packageRoot: packageRoot, sdkRoot: sdkRoot);
+    var resolver = new Resolver(packagesPath: packagesPath, sdkRoot: sdkRoot);
     var formatter = new LcovFormatter(resolver);
 
     var res = await formatter.format(hitmap);
@@ -91,7 +91,7 @@ class LcovCollector {
       var reportFile = await _getCoverageJson(testFile, tempDir);
 
       var hitmap = await parseCoverage(reportFile.result, workers);
-      var resolver = new Resolver(packageRoot: packageRoot, sdkRoot: sdkRoot);
+      var resolver = new Resolver(packagesPath: packagesPath, sdkRoot: sdkRoot);
       var formatter = new LcovFormatter(resolver);
 
       var res = await formatter.format(hitmap);
@@ -106,7 +106,7 @@ class LcovCollector {
       String testFile, Directory coverageDir) async {
     var args = [
       "--coverage_dir=${coverageDir.path}",
-      "--package-root=${packageRoot}",
+      "--packages=${packagesPath}",
       testFile
     ];
     var result = await processSystem.runProcess(Platform.executable, args);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: |-
   to LCOV and send it to coveralls
 homepage: https://github.com/duse-io/dart-coveralls
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: '>=1.20.0 <2.0.0'
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
   coverage: '>=0.6.4 <0.8.0'


### PR DESCRIPTION
This removes support for --packages-dir and adds support for --packages.

This also moves to the latest package:coverage which no longer uses
a coverage directory, but rather pulls coverage information from observatory.