### PR TITLE
Wait for execution to complete before collecting.

### DIFF
--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -135,8 +135,12 @@ class LcovCollector {
     Uri host = await hostCompleter.future;
 
     try {
-      Map<String, dynamic> coverageResults =
-          await collect(host, true, false, timeout: new Duration(seconds: 60));
+      Map<String, dynamic> coverageResults = await collect(
+        host,
+        /* resume isolate after collection */ true,
+        /* wait for pause-at-exit before collection */ true,
+        timeout: new Duration(seconds: 60),
+      );
       return coverageResults['coverage'];
     } catch (e) {
       print(e);


### PR DESCRIPTION
package:coverage already had an option for this, we just weren't
using it and it was difficult to tell because the api unfortunately
just uses raw booleans as parameter. :/

Fixes #61.