### PR TITLE
Remove plumbing for ignored --workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ To activate the program for global use, run `pub global activate dart_coveralls`
 This command calculates the coverage of a given package. Use the tool like this:
 
 ```
-dart_coveralls calc [--workers, --output, --package-root] test.dart
+dart_coveralls calc [--output, --package-root] test.dart
 # or
-dart_coveralls calc [--workers, --output, --packages] test.dart
+dart_coveralls calc [--output, --packages] test.dart
 ```
 
-* `--workers`: The number of workers used to parse LCOV information
 * `--output`: The output file path, if not given stdout
 * `--packages`: Specifies the path to the package resolution configuration file. 
    This option cannot be used with --package-root. Defaults to ".packages".
@@ -39,8 +38,6 @@ dart_coveralls report <options> <test file>
 
 * `--help` – Displays all options
 * `--token` –Token for coveralls
-* `--workers` – Number of workers for parsing
-  (defaults to "1")
 * `--packages`: Specifies the path to the package resolution configuration file. 
    This option cannot be used with --package-root. Defaults to ".packages".
 * `--package-root`: Specifies where to find imported libraries. 
@@ -67,8 +64,6 @@ dart_coveralls upload <options> <directory containing coverage reports from the 
 
 * `--help` – Displays all options
 * `--token` –Token for coveralls
-* `--workers` – Number of workers for parsing
-  (defaults to "1")
 * `--packages`: Specifies the path to the package resolution configuration file. 
    This option cannot be used with --package-root. Defaults to ".packages".
 * `--package-root`: Specifies where to find imported libraries. 

--- a/bin/src/calc.dart
+++ b/bin/src/calc.dart
@@ -37,12 +37,11 @@ class CalcPart extends CommandLinePart {
       return;
     }
 
-    var workers = int.parse(res["workers"]);
     var collector = new LcovCollector(
         packageRoot: pRoot is Directory ? pRoot.absolute.path : null,
         packagesPath: pRoot is File ? pRoot.absolute.path : null);
 
-    var r = await collector.getLcovInformation(file, workers: workers);
+    var r = await collector.getLcovInformation(file);
 
     if (res["output"] != null) {
       await new File(res["output"]).writeAsString(r);
@@ -54,8 +53,8 @@ class CalcPart extends CommandLinePart {
 
 ArgParser _initializeParser() {
   ArgParser parser = new ArgParser(allowTrailingOptions: true)
-    ..addOption("workers",
-        help: "Number of workers for parsing", defaultsTo: "1")
+    ..addOption("workers", help: "Ignored", defaultsTo: "1")
     ..addOption("output", help: "Output file path");
+
   return CommandLinePart.addCommonOptions(parser);
 }

--- a/bin/src/report.dart
+++ b/bin/src/report.dart
@@ -33,7 +33,6 @@ class ReportPart extends CommandLinePart {
       if (throwOnError) throw e;
     };
 
-    var workers = int.parse(res["workers"]);
     var retry = int.parse(res["retry"]);
     var throwOnConnectivityError = res["throw-on-connectivity-error"];
     var excludeTestFiles = res["exclude-test-files"];
@@ -46,7 +45,6 @@ class ReportPart extends CommandLinePart {
       }
 
       return await commandLineClient.reportToCoveralls(file.absolute.path,
-          workers: workers,
           dryRun: dryRun,
           retry: retry,
           throwOnConnectivityError: throwOnConnectivityError,
@@ -69,8 +67,7 @@ ArgParser _initializeParser() {
         help:
             "Token for coveralls. If not provided environment values REPO_TOKEN"
             " and COVERALLS_TOKEN are used if they exist.")
-    ..addOption("workers",
-        help: "Number of workers for parsing", defaultsTo: "1")
+    ..addOption("workers", help: "Ignored", defaultsTo: "1")
     ..addFlag("debug",
         help: "Prints all log information. Equivalent to `--log-level all`",
         negatable: false)

--- a/bin/src/upload.dart
+++ b/bin/src/upload.dart
@@ -23,7 +23,6 @@ class UploadPart extends CommandLinePart {
 
     var directory = new Directory(res.rest.single);
     var dryRun = res["dry-run"];
-    var workers = int.parse(res["workers"]);
     var retry = int.parse(res["retry"]);
     var throwOnError = res["throw-on-error"];
     var throwOnConnectivityError = res["throw-on-connectivity-error"];
@@ -47,7 +46,6 @@ class UploadPart extends CommandLinePart {
       }
 
       await commandLineClient.convertAndUploadToCoveralls(directory.absolute,
-          workers: workers,
           dryRun: dryRun,
           retry: retry,
           throwOnConnectivityError: throwOnConnectivityError,

--- a/lib/src/cli_client.dart
+++ b/lib/src/cli_client.dart
@@ -30,12 +30,12 @@ class CommandLineClient {
   }
 
   Future<String> getLcovResult(String testFile,
-      {int workers, ProcessSystem processSystem: const ProcessSystem()}) {
+      {ProcessSystem processSystem: const ProcessSystem()}) {
     var collector = new LcovCollector(
         packageRoot: packageRoot,
         packagesPath: packagesPath,
         processSystem: processSystem);
-    return collector.getLcovInformation(testFile, workers: workers);
+    return collector.getLcovInformation(testFile);
   }
 
   /// Returns [candidate] if not `null`, otherwise environment's `REPO_TOKEN` or
@@ -53,25 +53,22 @@ class CommandLineClient {
   }
 
   Future<CoverallsResult> reportToCoveralls(String testFile,
-      {int workers,
-      ProcessSystem processSystem: const ProcessSystem(),
+      {ProcessSystem processSystem: const ProcessSystem(),
       String coverallsAddress,
       bool dryRun: false,
       bool throwOnConnectivityError: false,
       int retry: 0,
       bool excludeTestFiles: false,
       bool printJson}) async {
-    var rawLcov = await getLcovResult(testFile,
-        workers: workers, processSystem: processSystem);
+    var rawLcov = await getLcovResult(testFile, processSystem: processSystem);
 
     if (rawLcov == null) {
-      print(
-          "Nothing to collect: Connection to VM service timed out. Make sure your test file is free from errors: ${testFile}");
+      print("Nothing to collect: Connection to VM service timed out. "
+          "Make sure your test file is free from errors: ${testFile}");
       exit(0);
     }
 
     return uploadToCoveralls(rawLcov,
-        workers: workers,
         processSystem: processSystem,
         coverallsAddress: coverallsAddress,
         dryRun: dryRun,
@@ -83,8 +80,7 @@ class CommandLineClient {
 
   Future<CoverallsResult> convertAndUploadToCoveralls(
       Directory containsVmReports,
-      {int workers,
-      ProcessSystem processSystem: const ProcessSystem(),
+      {ProcessSystem processSystem: const ProcessSystem(),
       String coverallsAddress,
       bool dryRun: false,
       bool throwOnConnectivityError: false,
@@ -96,11 +92,9 @@ class CommandLineClient {
         packagesPath: packagesPath,
         processSystem: processSystem);
 
-    var result = await collector.convertVmReportsToLcov(containsVmReports,
-        workers: workers);
+    var result = await collector.convertVmReportsToLcov(containsVmReports);
 
     return uploadToCoveralls(result,
-        workers: workers,
         processSystem: processSystem,
         dryRun: dryRun,
         throwOnConnectivityError: throwOnConnectivityError,
@@ -110,8 +104,7 @@ class CommandLineClient {
   }
 
   Future<CoverallsResult> uploadToCoveralls(String coverageResult,
-      {int workers,
-      ProcessSystem processSystem: const ProcessSystem(),
+      {ProcessSystem processSystem: const ProcessSystem(),
       String coverallsAddress,
       bool dryRun: false,
       bool throwOnConnectivityError: false,

--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -62,21 +62,20 @@ class LcovCollector {
       this.processSystem: const ProcessSystem(),
       this.sdkRoot}) {}
 
-  Future<String> convertVmReportsToLcov(Directory directoryContainingVmReports,
-      {int workers: 1}) async {
+  Future<String> convertVmReportsToLcov(
+      Directory directoryContainingVmReports) async {
     var reportFiles = await directoryContainingVmReports
         .list(recursive: false, followLinks: false)
         .toList();
 
-    var hitmap = await parseCoverage(reportFiles as Iterable<File>, workers);
+    var hitmap = await parseCoverage(reportFiles as Iterable<File>, null);
     return await _formatCoverageJson(hitmap);
   }
 
   /// Returns an LCOV string of the tested [File].
   ///
   /// Calculates and returns LCOV information of the tested [File].
-  /// This uses [workers] to parse the collected information.
-  Future<String> getLcovInformation(String testFile, {int workers: 1}) async {
+  Future<String> getLcovInformation(String testFile) async {
     if (!p.isAbsolute(testFile)) {
       throw new ArgumentError.value(
           testFile, 'testFile', 'Must be an absolute path.');


### PR DESCRIPTION
I've left the option in, but removed all the dead plumbing.
The workers parameter is ignored recent versions of
package:coverage.