### PR TITLE
Update SDK and package:coverage version ranges

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,20 +4,20 @@ author: Axel Christ <adracus@gmail.com>
 description: |-
   Pub package to calculate coverage, format it
   to LCOV and send it to coveralls
-homepage: https://github.com/duse-io/dart-coveralls
+homepage: https://github.com/block-forest/dart-coveralls
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: ^1.16.0
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
-  coverage: '>=0.6.4 <0.10.0'
+  coverage: ^0.9.2
   http: '>=0.11.1+1 <0.12.0'
   logging: '>=0.9.2 <0.12.0'
   mockable_filesystem: '>=0.0.3 <0.1.0'
-  path: '>=1.3.0 <2.0.0'
+  path: ^1.3.0
   stack_trace: ^1.3.2
-  yaml: '>=2.1.2 <3.0.0'
+  yaml: ^2.1.2
 dev_dependencies:
-  mock: '^0.12.0'
-  test: '^0.12.0'
+  mock: ^0.12.0
+  test: ^0.12.0
 executables:
   dart_coveralls: null


### PR DESCRIPTION
Also deployed carrot syntax everywhere, removed quotes and updated
homepage to refect the recent change of package ownership.

Fixes https://github.com/block-forest/dart-coveralls/issues/65