### PR TITLE
Fix pub publish warning about SDK constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: |-
   to LCOV and send it to coveralls
 homepage: https://github.com/block-forest/dart-coveralls
 environment:
-  sdk: ^1.16.0
+  sdk: ">=1.16.0 <2.0.0"
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
   coverage: ^0.9.2


### PR DESCRIPTION
Missing requirements:
* ^ version constraints aren't allowed for SDK constraints since older versions of pub don't support them.
  Expand it manually instead.