### PR TITLE
Update coveralls.io badge to the new URL pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 dart-coveralls
 ==============
 
-[![Build Status](https://travis-ci.org/block-forest/dart-coveralls.svg?branch=master)](https://travis-ci.org/block-forest/dart-coveralls) [![Coverage Status](https://coveralls.io/repos/block-forest/dart-coveralls/badge.svg)](https://coveralls.io/r/block-forest/dart-coveralls)
+[![Build Status](https://travis-ci.org/block-forest/dart-coveralls.svg?branch=master)](https://travis-ci.org/block-forest/dart-coveralls)
+[![Coverage Status](https://coveralls.io/repos/github/block-forest/dart-coveralls/badge.svg?branch=master)](https://coveralls.io/github/block-forest/dart-coveralls?branch=master)
 
 Calculate coverage of your dart scripts, format it to LCOV and send it to
 [coveralls.io](https://coveralls.io/).


### PR DESCRIPTION
This should make the warning on coveralls.io go away.