### PR TITLE
Move to using source_digest instead of source

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
   coverage: ^0.9.2
+  crypto: ^2.0.1
   http: '>=0.11.1+1 <0.12.0'
   logging: '>=0.9.2 <0.12.0'
   mockable_filesystem: '>=0.0.3 <0.1.0'

--- a/test/coveralls_entities_test.dart
+++ b/test/coveralls_entities_test.dart
@@ -1,5 +1,7 @@
 library dart_coveralls.test.coveralls_entities;
 
+import 'dart:convert';
+
 import 'package:dart_coveralls/dart_coveralls.dart';
 import 'package:mock/mock.dart';
 import 'package:test/test.dart';
@@ -161,7 +163,7 @@ void main() {
 
   group('SourceFileReport', () {
     test('toJson', () {
-      var file = new SourceFile('a', 'b');
+      var file = new SourceFile('a', UTF8.encode('b'));
 
       var str = "DA:3,3\nDA:4,5\nDA:6,3";
       var coverage = Coverage.parse(str);
@@ -172,8 +174,8 @@ void main() {
           report.toJson(),
           equals({
             'name': 'a',
-            'source': 'b',
-            "coverage": [null, null, 3, 5, null, 3]
+            'source_digest': '92eb5ffee6ae2fec3ad71c777531578f',
+            'coverage': [null, null, 3, 5, null, 3]
           }));
     });
   });


### PR DESCRIPTION
This matches the most recent coveralls documentation:
https://coveralls.zendesk.com/hc/en-us/articles/201350799-API-Reference
And will dramatically reduce the upload size for lage projects
and hopefully reduce the number of "Bad gateway" errors
we seem to be seeing in the wild.

Fixes https://github.com/block-forest/dart-coveralls/issues/70
And may affect https://github.com/block-forest/dart-coveralls/issues/68

After this change, json length for dart-coveralls repo submission goes from
35537 bytes to 5378 bytes.  Larger projects will see larger gains.