### PR TITLE
Change travis.sh to use --throw-on-error

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -13,6 +13,8 @@ if [ "$COVERALLS_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "stable" ]; then
   dart bin/dart_coveralls.dart report \
     --retry 2 \
     --exclude-test-files \
+    --throw-on-error \
+    --throw-on-connectivity-error \
     --debug \
     test/test_all.dart
   echo "Coverage complete."


### PR DESCRIPTION
Also added --throw-on-connectivity error.

There is a lot more we should do here, but this is a start.

Fixes https://github.com/block-forest/dart-coveralls/issues/68.