### PR TITLE
fixed Exception and upgraded coverage dependency

### DIFF
--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -88,7 +88,7 @@ class LcovCollector {
       return null;
     }
 
-    Map<String, dynamic> hitmap = {};
+    Map<String, Map<int, int>> hitmap = {};
     mergeHitmaps(createHitmap(reportFile), hitmap);
     return await _formatCoverageJson(hitmap);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,10 @@ description: |-
   to LCOV and send it to coveralls
 homepage: https://github.com/block-forest/dart-coveralls
 environment:
-  sdk: ">=2.0.0-dev.55.0 <2.0.0"
+  sdk: ">=2.0.0-dev.64.1 <2.0.0"
 dependencies:
   args: '>=0.12.1 <2.0.0'
-  coverage: ^0.10.0
+  coverage: ^0.12.0
   crypto: ^2.0.1
   file: ^2.3.7
   http: '>=0.11.1+1 <0.12.0'


### PR DESCRIPTION
I fixed the type of `hitmap` and updated the `coverage` dependency because `dart-coveralls` failed with the following Exception (probably since Dart 2.0.0-dev.64.1):

```
type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Map<int, int>>'
package:dart_coveralls/src/collect_lcov.dart 92:44  LcovCollector.getLcovInformation
===== asynchronous gap ===========================
dart:async                                          _AsyncAwaitCompleter.completeError
package:dart_coveralls/src/collect_lcov.dart        LcovCollector.getLcovInformation
===== asynchronous gap ===========================
dart:async                                          _asyncThenWrapperHelper
package:dart_coveralls/src/collect_lcov.dart        LcovCollector.getLcovInformation
package:dart_coveralls/src/cli_client.dart 40:22    CommandLineClient.getLcovResult
package:dart_coveralls/src/cli_client.dart 66:25    CommandLineClient.reportToCoveralls
```